### PR TITLE
Improving the way the plugin checks if a given stall sells balloons

### DIFF
--- a/Random.Balloon.Colours.js
+++ b/Random.Balloon.Colours.js
@@ -1,4 +1,4 @@
-const balloonStallType = 32;
+const balloonItemType = 0;
 const namespace = 'random_balloon_colours';
 const changeStallBalloonColourKey = namespace + ".changeStallBalloonColour"
 const changePeepBalloonColourKey = namespace + ".changePeepBalloonColour"
@@ -21,7 +21,7 @@ const changeStallBalloonColour = function() {
         if (item.classification != 'stall') {
             continue;
         }
-        if (item.type != balloonStallType) {
+        if (item.object.shopItem != balloonItemType && item.object.shopItemSecondary != balloonItemType) {
             continue;
         }
         item.colourSchemes = [{main: context.getRandom(0, 31)}];
@@ -63,7 +63,7 @@ const showWindow = function() {
       window.bringToFront();
       return;
     }
-  
+
     ui.openWindow({
         classification: namespace,
         width: 240,


### PR DESCRIPTION
Currently the plugin checks the Ride.Type integer to see if the stall is one that sells balloons. The Ride.Type 32 is also shared with T-Shirt stalls, Souvenir Stalls, and Hat Stalls meaning that it will change the colors of the T-Shirts, Hats, and Umbrellas sold at these stalls as well (but not Umbrellas sold at Information Kiosks since those are categorized as facilities).

It would be better to check the Ride.Object.shopItem and Ride.Object.shopItemSecondary integer to see if the stall sells balloons (the number for balloons is 0).